### PR TITLE
EnvProxy API changes

### DIFF
--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -31,9 +31,9 @@ module HerokuBuildpackRuby
     ).call
 
     EnvProxy.export(
-      export: export,
       app_dir: app_dir,
-      profile_d: profile_d_path,
+      export_path: export,
+      profile_d_path: profile_d_path,
     )
   end
 

--- a/lib/heroku_buildpack_ruby/env_proxy.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy.rb
@@ -10,28 +10,40 @@ module HerokuBuildpackRuby
   #
   # The main interface is the EnvProxy module. For example, to create a proxy for: ENV["PATH"]
   #
-  #   app_dir = "/app"
   #   PATH_ENV = EnvProxy.path("PATH")
-  #   PATH_ENV.prepend(ruby: "#{app_dir}/.heroku/ruby/path/bin")
   #
-  # This will modify the current build path
+  # This will modify the current build path:
   #
+  #   PATH_ENV.prepend(ruby: "/app/.heroku/ruby/path/bin")
   #   puts ENV["PATH"] => "/app/.heroku/ruby/path/bin:/whatever/was/here/before"
   #
-  # The proxy retains the modifications so they can be written to disk:
+  # The proxy retains modifications so they can be written to disk for various interfaces. Such as CNB and v2/legacy.
+  # The key for the value represents the layer it will be written to. This example shows writing to a ruby layer:
   #
-  #   ruby_sh = Pathname.new(app_dir).join(".profile.d/ruby.sh")
-  #   EnvProxy.export(ruby_sh)
-  #   puts ruby_sh.read # => "export PATH="/app/.heroku/ruby/path/bin:$PATH"
+  #   PATH_ENV.prepend(ruby: "/app/.heroku/ruby/path/bin")
   #
-  # The key used when modifying a proxied env var can be used to write more granular layer info when using CNBs:
+  # Later when all layers are written to we can expect to see this environment variable set in the layers dir
+  # via the `EnvProxy.write_layers` method:
   #
   #   layers_dir = Pathname.new(layers_dir)
   #   EnvProxy.write_layers(layers_dir: layers_dir)
   #
   #   puts layers_dir.join("ruby/launch.env").entries # => "PATH"
-  #   puts layers_dir.join("ruby/launch.env").read # => "/app/.heroku/ruby/path/bin"
+  #   puts layers_dir.join("ruby/launch.env/PATH").read # => "/app/.heroku/ruby/path/bin"
   #   puts layers_dir.join("ruby.toml").read.lines.grep(/launch/) # => "launch = true\n"
+  #
+  # > Note: this method also generates a `ruby.toml`. To configure the contents use `EnvProxy.register_layer`.
+  #
+  # To write to an export file such as profile.d script or a bash profile you can use the `EnvProxy.export_to` interface
+  # which support v2/legacy:
+  #
+  #   ruby_sh = Pathname.new("/app").join(".profile.d/ruby.sh")
+  #   export = Pathname.new(BUILDPACK_PATH).join("export")
+  #
+  #   EnvProxy.export_to(profile_d_path: ruby_sh, export_path: export_path, app_dir: "/app")
+  #
+  #   puts ruby_sh.read # => "export PATH="/app/.heroku/ruby/path/bin:$PATH"
+  #
   #
   # There are several ways to proxy an env var:
   #
@@ -42,7 +54,8 @@ module HerokuBuildpackRuby
   #
   #   EnvProxy.register_layer(:ruby, build: true, launch: true, cache: false)
   #
-  # For `EnvProxy.export` layer names are ignored as all values are output to the same file
+  # For `EnvProxy.export_to` the layer names are ignored as all values are output to the same file
+  #
   module EnvProxy
     extend Enumerable
 
@@ -98,7 +111,7 @@ module HerokuBuildpackRuby
     #
     #   puts ENV["LOL"] #=> "hehe"
     def self.value(key)
-      value = EnvProxy::Value.new(key)
+      value = EnvProxy::Override.new(key)
       @env_array << value
       value
     end
@@ -117,7 +130,7 @@ module HerokuBuildpackRuby
     #
     #   puts ENV["LOL_PATH"] #=> "hehe:ha:ha"
     def self.path(key)
-      value = EnvProxy::Array.new(key)
+      value = EnvProxy::Prepend.new(key)
       @env_array << value
       value
     end
@@ -138,158 +151,37 @@ module HerokuBuildpackRuby
 
     # Top level interface for exporting env vars for profiled
     # and export file to other buildpacks
-    def self.export(profile_d: , export: , app_dir: )
-      profile_d_file = Pathname.new(profile_d).tap {|p| p.dirname.mkpath }
-      export_file= Pathname.new(export)
+    def self.export(profile_d_path: , export_path: , app_dir: )
+      profile_d_path = Pathname.new(profile_d_path).tap {|p| p.dirname.mkpath }
+      export_path = Pathname.new(export_path)
 
-      # Runtime, needs to escape app_dir with $HOME
-      profile_d_file.open("w") do |f|
-        @env_array.each do |env|
-          f.puts env.to_export(replace_app_dir: app_dir)
-        end
-      end
-
-      # Build time for other buildpacks, run in the same dir structure
-      export_file.open("w") do |f|
-        @env_array.each do |env|
-          f.puts env.to_export
-        end
+      @env_array.each do |env|
+        env.write_exports(
+          app_dir: app_dir,
+          profile_d_path: profile_d_path,
+          export_path: export_path
+        )
       end
     end
 
     # Used to wrote all ENV vars to their correct env files
     # with cloud native buildpacks
     def self.write_layers(layers_dir: )
+      layers_dir = Pathname.new(layers_dir)
+
       @registered_layers.each do |name, config|
-        layers_dir = Pathname.new(layers_dir)
+        contents = TOML::Dumper.new(config).to_s
+        layers_dir.join("#{name}.toml").write(contents)
+      end
 
-        toml_file = layers_dir.join("#{name}.toml")
-        toml_file.write(TOML::Dumper.new(config).to_s)
-
-        @env_array.select {|env| env.touches_layer?(name) }.each do |env|
-          env.write_layer(
-            layers_dir: layers_dir,
-            name: name,
-          )
-        end
+      @env_array.each do |env|
+        env.write_layer(layers_dir: layers_dir)
       end
     end
   end
 
-  class EnvProxy::Base
-    attr_reader :key
-
-    def initialize(key)
-      @key = key
-
-      @layer_env_hash = {}
-    end
-
-    def touches_layer?(name)
-      @layer_env_hash.key?(name)
-    end
-
-    def layer_key
-      key
-    end
-
-    def write_layer(layers_dir: , name:)
-      layer = Pathname.new(layers_dir).join(name.to_s)
-      launch_dir = layer.join("env.launch").tap(&:mkpath)
-      build_dir = layer.join("env.build").tap(&:mkpath)
-
-      build_dir.join(self.layer_key).open("w+") do |f|
-        value = Array(@layer_env_hash[name]).join(":")
-        f.write(value)
-      end
-
-      launch_dir.join(self.layer_key).open("w+") do |f|
-        value = Array(@layer_env_hash[name]).join(":")
-        f.write(value)
-      end
-    end
-
-    private def layer_env_hash_without(app_dir: nil)
-      return @layer_env_hash.dup if app_dir.nil?
-
-      @layer_env_hash.each_with_object({}) do |(name, value), hash|
-        hash[name] = Array(value).flatten.map {|v| v.gsub(/^#{app_dir}/, '$HOME') }.join(":")
-      end
-    end
-  end
-
-  # Used for setting a single value on an env var
-  #
-  # Example:
-  #
-  #   puts ENV["LOL"] #=> "haha"
-  #   LOL_ENV = EnvProxy.value("LOL")
-  #   LOL_ENV.set(ruby: "hehe")
-  #
-  #   puts ENV["LOL"] #=> "hehe"
-  #
-  class EnvProxy::Value < EnvProxy::Base
-    def layer_key
-      "#{key}.override"
-    end
-
-    def set(layer_env = {})
-      if layer_env.values.uniq.count > 1
-        raise "You've tried setting assigning the same ENV var to different values #{layer_env.values}"
-      end
-      @layer_env_hash.merge!(layer_env)
-
-      value = layer_env.values.first.to_s
-
-      @layer_env_hash.keys.each do |k|
-        EnvProxy.validate_layer!(k)
-        @layer_env_hash[k] = value
-      end
-
-      ENV[@key] = value
-    end
-
-    def to_export(replace_app_dir: nil)
-      layer_env_hash_without(app_dir: replace_app_dir).map do |name, value|
-        %Q{export #{key}="#{value}"}
-      end.join("\n")
-    end
-  end
-
-
-  # Used for prepending a value to a path based env var
-  #
-  # Example:
-  #
-  #   puts ENV["LOL_PATH"] #=> "ha:ha"
-  #   LOL_PATH_ENV = EnvProxy.path("LOL_PATH")
-  #   LOL_PATH_ENV.prepend(ruby: "hehe")
-  #
-  #   puts ENV["LOL_PATH"] #=> "hehe:ha:ha"
-  class EnvProxy::Array < EnvProxy::Base
-    def prepend(layer_env = {})
-      all_values = []
-      layer_env.each do |layer_name, value|
-        EnvProxy.validate_layer!(layer_name)
-
-        value = Array(value).map(&:to_s)
-        all_values << value
-
-        @layer_env_hash[layer_name] ||= []
-        @layer_env_hash[layer_name].prepend(value)
-      end
-
-      ENV[@key] = [all_values, ENV[key]].compact.join(":")
-    end
-
-    def to_export(replace_app_dir: nil)
-      layer_env_hash_without(app_dir: replace_app_dir).map do |name, array|
-        value = [array, "$#{key}"].join(":")
-        %Q{export #{key}="#{value}"}
-      end.join("\n")
-    end
-  end
-
+  require_relative "env_proxy/prepend.rb"
+  require_relative "env_proxy/override.rb"
   PATH_ENV = EnvProxy.path("PATH")
   GEM_PATH_ENV = EnvProxy.path("GEM_PATH")
   BUNDLE_GEMFILE_ENV = EnvProxy.value("BUNDLE_GEMFILE")

--- a/lib/heroku_buildpack_ruby/env_proxy/base.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy/base.rb
@@ -1,0 +1,170 @@
+module HerokuBuildpackRuby
+  # Base class for EnvProxy types
+  #
+  # Docs here are for implementing your own subclass
+  #
+  # If you subclass you'll need to implement:
+  #
+  # - (set|prepend|<user-defined>): A method for importing data. Such as `set` for values and `prepend` for paths. You pick a method
+  #   name to match the semantics you are expecting for the proxy type.
+  # - `private def value_for_export`: This method converts ALL layer values to a singular value used for exporting to v2 interface
+  #   this will be called once without arguments for writing an export file that sets env vars for later buildpacks
+  #   as well as being called once with `replace:` and `with:` for writing an export file that writes to profile_d
+  #   file for runtime execution
+  # - `def layer_env_type`: A method that returns one of: [:prepend, :append, :override, :default] corresponding to the behavior
+  #   of the environment variable coresponding to the layer https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules
+  #
+  # Internal structure:
+  #
+  # - @layer_env_hash: Is a hash, the keys represent names of layers for CNB, the values represent values where env modifications
+  #   can be recorded. Different subclasses may have different value representations. For instance the PATH proxy is represented by arrays
+  #   while a value env like BUNDLE_GEMFILE proxy is represented by a single value.
+  #
+  #   Example: {ruby: "Gemfile"} in this case the "ruby" layer would have a value of "Gemfile" for the initialized key
+  #
+  # Provides the following interfaces to subclasses:
+  #
+  #   attr_reader :key
+  #
+  #   def initialize(key)
+  #   def write_layer(layers_dir: )
+  #   def write_exports(profile_d_path: , export_path: , app_dir: )
+  #   def to_export(replace: "", with: "")
+  class EnvProxy::Base
+    attr_reader :key
+
+    # Do not create directly
+    # or it won't be tracked by EnvProxy instead use env proxy
+    # class methods:
+    #
+    # - EnvPxoxy.value("FOO")
+    # - EnvPxoxy.path("FOO_PATH")
+    #
+    def initialize(key)
+      @key = key
+
+      @layer_env_hash = {}
+    end
+
+    # Returns one of [:prepend, :append, :override, :default]
+    private def layer_env_type
+      raise "Must subclass"
+    end
+
+    # Used by subclasses to determine how `to_export` behaves
+    # for instance when prepending a path, we want the export to
+    # always end in the key
+    private def value_for_export(replace: "", with: "")
+      raise "Must subclass"
+    end
+
+    # Returns a formatted string used for writing an export
+    # to a bash script
+    #
+    # Example:
+    #
+    #  LOL_PATH_ENV = EnvProxy.path("LOL_PATH")
+    #  LOL_PATH_ENV.prepend(ruby: "/app/lol")
+    #  LOL_PATH_ENV.prepend(gems: "/app/rofl")
+    #
+    #  puts LOL_PATH.to_export # => 'export LOL_PATH="/app/rofl:/app/lol:$LOL_PATH"
+    #  puts LOL_PATH.to_export(replace: "/app", with: "$HOME") # => 'export LOL_PATH="$HOME/rofl:$HOME/lol:$LOL_PATH"
+    #
+    def to_export(replace: "", with: "")
+      value = value_for_export(replace: replace, with: with)
+      %Q{export #{key}="#{value}"}
+    end
+
+    # Writes the contents of the env var to the given layer
+    #
+    # Note: That both build and launch layers are written
+    #       for every env var, but whether they're used or
+    #       not is dependent on how they're configured via
+    #       `EnvProxy.register_layer`
+    #
+    # Example:
+    #
+    #   LOL_PATH_ENV = EnvProxy.path("LOL_PATH")
+    #   LOL_PATH_ENV.prepend(ruby: "/app/lol")
+    #   LOL_PATH_ENV.prepend(gems: "/app/rofl")
+    #
+    #   layers_dir = Pathname.new(Dir.mktmpdir)
+    #   LOL_PATH.write_exports(
+    #     layers_dir: layers_dir
+    #   )
+    #
+    #   layers_dir.join("ruby/env.launch/LOL_PATH") # => "/app/lol"
+    #   layers_dir.join("gems/env.launch/LOL_PATH") # => "/app/rofl"
+    #
+    def write_layer(layers_dir: )
+      @layer_env_hash.each do |name, v|
+        layer = Pathname.new(layers_dir).join(name.to_s)
+        launch_dir = layer.join("env.launch").tap(&:mkpath)
+
+        build_dir = layer.join("env.build").tap(&:mkpath)
+        value = Array(v).join(":")
+        build_dir.join(self.layer_key).open("w+") do |f|
+          f.write(value)
+        end
+
+        launch_dir.join(self.layer_key).open("w+") do |f|
+          f.write(value)
+        end
+      end
+    end
+
+    # Writes the contents of the env var to the given profile.d file
+    # and export file.
+    #
+    # profile.d contents are stripped so that any value that starts with
+    # the app_dir path is turned into $HOME since the build and
+    # runtime directory structure are different
+    #
+    # Example:
+    #
+    #  LOL_PATH_ENV = EnvProxy.path("LOL_PATH")
+    #  LOL_PATH_ENV.prepend(ruby: "/app/lol")
+    #  LOL_PATH_ENV.prepend(gems: "/app/rofl")
+    #
+    #  profile_d = Tempfile.new
+    #  export = Tempfile.new
+    #  LOL_PATH.write_exports(
+    #    profile_d_path: profile_d.path
+    #    export_path: export.path,
+    #    app_dir: "/app"
+    #  )
+    #
+    #  puts File.read(profile_d) # => 'export LOL_PATH="$HOME/rofl:$HOME/lol:$LOL_PATH"
+    #  puts File.read(export) # => 'export LOL_PATH="/app/rofl:/app/lol:$LOL_PATH"'
+    #
+    def write_exports(profile_d_path: , export_path: , app_dir: )
+      profile_d_path = Pathname.new(profile_d_path)
+      export_path = Pathname.new(export_path)
+
+      profile_d_path.open("a") do |f|
+        f.write(to_export(replace: app_dir, with: "$HOME"))
+      end
+
+      export_path.open("a") do |f|
+        f.write(to_export)
+      end
+    end
+
+    # Generates the appropriate layer file name
+    # for the given layer type
+    #
+    # v = EnvProxy.value("FOO")
+    # v.layer_env_type # => :override
+    # v.layer_key # => "FOO.override"
+    private def layer_key
+      case layer_env_type
+      when :append, :override, :default
+        [key, layer_env_type].join(".")
+      when :prepend
+        key
+      else
+        raise "No such layer env type #{layer_env_type}"
+      end
+    end
+  end
+end

--- a/lib/heroku_buildpack_ruby/env_proxy/override.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy/override.rb
@@ -1,0 +1,62 @@
+require_relative "base.rb"
+
+module HerokuBuildpackRuby
+  # Used for setting a single value on an env var
+  #
+  # Example:
+  #
+  #   puts ENV["LOL"] #=> "haha"
+  #
+  #   LOL_ENV = EnvProxy.value("LOL")
+  #   LOL_ENV.set(ruby: "hehe")
+  #
+  #   puts ENV["LOL"] #=> "hehe"
+  #
+  # Receives the following interfaces from the super class:
+  #
+  #   attr_reader :key
+  #
+  #   def initialize(key)
+  #   def write_layer(layers_dir: )
+  #   def write_exports(profile_d_path: , export_path: , app_dir: )
+  #   def to_export(replace: "", with: "")
+  class EnvProxy::Override < EnvProxy::Base
+    # Tells CNB to clobber any existing env vars with the same
+    # key. https://github.com/buildpacks/spec/blob/main/buildpack.md#override
+    def layer_env_type
+      :override
+    end
+
+    # Main method for changing the value of the env var
+    def set(layer_env = {})
+      @layer_env_hash.merge!(layer_env)
+
+      validate!
+
+      value = layer_env.values.first.to_s
+
+      @layer_env_hash.keys.each do |k|
+        EnvProxy.validate_layer!(k)
+        @layer_env_hash[k] = value
+      end
+
+      ENV[@key] = value
+    end
+
+    # Implement interface used by `for_export()` method to write profile_d and export files
+    # outputs a singular value that has contents of all layers
+    private def value_for_export(replace: "", with: "")
+      @layer_env_hash.values.flatten.map {|v| v.sub(/^#{replace}/, with) }.first
+    end
+
+    # Since this class represents a singular value, all layer values must match
+    # or we get undefined behavior based on load order
+    private def validate!
+      values = @layer_env_hash.values.map(&:to_s)
+      values.uniq!
+      if values.count > 1
+        raise "You cannot set the same ENV var (#{key}) to different values values: #{values}, full_hash: #{@env_layer_hash.inspect}"
+      end
+    end
+  end
+end

--- a/lib/heroku_buildpack_ruby/env_proxy/prepend.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy/prepend.rb
@@ -1,0 +1,53 @@
+require_relative "base.rb"
+
+module HerokuBuildpackRuby
+  # Used for prepending a value to a path based env var
+  #
+  # Example:
+  #
+  #   puts ENV["LOL_PATH"] #=> "ha:ha"
+  #   LOL_PATH_ENV = EnvProxy.path("LOL_PATH")
+  #   LOL_PATH_ENV.prepend(ruby: "hehe")
+  #
+  #   puts ENV["LOL_PATH"] #=> "hehe:ha:ha"
+  #   puts LOL_PATH_ENV.to_export # => 'export LOL_PATH="hehe:$LOL_PATH"'
+  #
+  # Receives the following interfaces from the super class:
+  #
+  #   attr_reader :key
+  #
+  #   def initialize(key)
+  #   def write_layer(layers_dir: )
+  #   def write_exports(profile_d_path: , export_path: , app_dir: )
+  #   def to_export(replace: "", with: "")
+  class EnvProxy::Prepend < EnvProxy::Base
+    # CNB filename for exports, prepend value https://github.com/buildpacks/spec/blob/main/buildpack.md#prepend
+    def layer_env_type
+      :prepend
+    end
+
+    # Main method for changing the value of the env var
+    def prepend(layer_env = {})
+      all_values = []
+      layer_env.each do |layer_name, value|
+        EnvProxy.validate_layer!(layer_name)
+
+        value = Array(value).map(&:to_s)
+        all_values << value
+
+        @layer_env_hash[layer_name] ||= []
+        @layer_env_hash[layer_name].prepend(value)
+      end
+
+      ENV[@key] = [all_values, ENV[key]].compact.join(":")
+    end
+
+    # Implement interface used by `for_export()` method to write profile_d and export files
+    # outputs a singular value that has contents of all layers
+    private def value_for_export(replace: "", with: "")
+      values = @layer_env_hash.values.reverse.flatten.map {|v| v.sub(/^#{replace}/, with) }
+      [values, "$#{key}"].join(":")
+    end
+  end
+
+end


### PR DESCRIPTION
Lots of docs, lots of small tweaks to the API. This feels pretty good. See fairly comprehensive list of changes below. Conceptually the interfaces better match the intent of using the objects. I don't love the pattern of having a "base" class and inhering from it. But I also don't want to jump through hoops to guarantee logic and methods are available for all EnvProxy types.

We're currently implementing the prepend and override logic. We're missing append, which I don't think we'll need. We're also missing default, which might be useful, but I'll wait until I actually need it before I try to define an interface for it. 

I'm also moving the classes to their own files as I think this interface is likely good enough to stick around for awhile.

Here's a detailed list of changes

## EnvProxy

- EnvProxy.export method signature changed so that directory kwargs end in *_dir
- EnvProxy.export behavior changed so it writes to the profile d and export file at the same time instead of needing to be called twice with different arguments

## EnvProxy::Base

- EnvProxy::Base#write_layer changed to write all layers at once instead of only writing one named layer at a time. This removes `name:` from the method signature.
- EnvProxy::Base#touches_layer? removed since `write_layer` now writes all layers at once
- EnvProxy::Base#to_export method signature changed from `replace_app_dir:` to `replace:, with:`. This method is now implemented on the base class instead of sub classes
- EnvProxy::Base#value_for_export is now a required implemented method from subclasses
- EnvProxy::Base#layer_key is now implemented by the base class, the interface for changing the layer filename has moved to #layer_env_type
- EnvProxy::Base#layer_env_type is now expected to be implemented by subclasses it can be :append, :overwrite, :default, or :prepend
- Moved to it's own file
- Class documentation with an example
- Every method has documentation with an example

## EnvProxy::Value renamed to EnvProxy::Override

The name of the class better matches the CNB logic. 

- Now implements `layer_env_type` of :override since setting this value is intended to replace other values
- Internal #validate! class added. Validation logic is moved to that method and is now more robust
- #to_export removed since it is now implemented in the base class. Instead `value_for_export` is implemented which is now consumed by EnvProxy::Base#to_export
- Moved to it's own file
- Class documentation with an example
- Every method has documentation


## EnvProxy::Array renamed to EnvProxy::Prepend

The name of the class better matches the CNB logic

- Now implements `layer_env_type` of :prepend since setting this value is intended to prepend existing values
- #to_export removed since it is now implemented in the base class. Instead `value_for_export` is implemented which is now consumed by EnvProxy::Base#to_export
- Moved to it's own file
- Class documentation with an example
- Every method has documentation